### PR TITLE
Simplified version check

### DIFF
--- a/Tests/test_file_gif.py
+++ b/Tests/test_file_gif.py
@@ -794,6 +794,9 @@ def test_comment(tmp_path):
     with Image.open(out) as reread:
         assert reread.info["comment"] == im.info["comment"].encode()
 
+        # Test that GIF89a is used for comments
+        assert reread.info["version"] == b"GIF89a"
+
 
 def test_comment_over_255(tmp_path):
     out = str(tmp_path / "temp.gif")
@@ -805,7 +808,8 @@ def test_comment_over_255(tmp_path):
     im.save(out)
     with Image.open(out) as reread:
         assert reread.info["comment"] == comment
-        # Test that GIF89a is used for long comment
+
+        # Test that GIF89a is used for comments
         assert reread.info["version"] == b"GIF89a"
 
 

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -912,17 +912,16 @@ def _get_global_header(im, info):
     # https://www.matthewflickinger.com/lab/whatsinagif/bits_and_bytes.asp
 
     version = b"87a"
-    for extensionKey in ["transparency", "duration", "loop", "comment"]:
-        if info and extensionKey in info:
-            if (extensionKey == "duration" and info[extensionKey] == 0) or (
-                extensionKey == "comment" and len(info[extensionKey]) == 0
-            ):
-                continue
-            version = b"89a"
-            break
-    else:
-        if im.info.get("version") == b"89a":
-            version = b"89a"
+    if im.info.get("version") == b"89a" or (
+        info
+        and (
+            "transparency" in info
+            or "loop" in info
+            or info.get("duration")
+            or info.get("comment")
+        )
+    ):
+        version = b"89a"
 
     background = _get_background(im, info.get("background"))
 


### PR DESCRIPTION
Hi. Two suggestions for https://github.com/python-pillow/Pillow/pull/6292.

1. A modified copy of your idea from https://github.com/python-pillow/Pillow/issues/6291#issue-1235628952 to rearrange the code.
2. Add the new check to `test_comment` as well. It's a reasonable approach to only test the changed behaviour, this is just me testing how things should behave in that scenario as well, and saving my initial confusion when I thought you were suggesting that comments over 255 characters were special in the GIF specification in some way.